### PR TITLE
Add per-location views, statuses on the table

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,7 +16,7 @@ import static
 from flask import Flask, make_response, render_template
 from render_utils import make_context, smarty_filter, urlencode_filter
 from werkzeug.debug import DebuggedApplication
-from helpers import format_zip
+from helpers import *
 
 app = Flask(__name__)
 app.debug = app_config.DEBUG
@@ -39,6 +39,14 @@ def index():
 
     return make_response(render_template('index.html', **context))
 
+@app.route('/locations')
+@app.route('/locations/')
+def table_redirect():
+    """
+    redirect people looking for a list of locations to the main page
+    """
+    return redirect( '/', code='303' ) # 303 See Other
+
 @app.route('/table.html')
 def table():
     """
@@ -56,6 +64,30 @@ def embedding():
     context = make_context()
 
     return make_response(render_template('embedding.html', **context))
+
+@app.route('/embedding.html')
+def embedding():
+    """
+    instructions on embedding this item
+    """
+    context = make_context()
+
+    return make_response(render_template('embedding.html', **context))
+
+location_ids = get_location_ids()
+for location in location_ids: # 'id' is a __builtin__
+    @app.route('/location/%s' % location, endpoint=location)
+    def location():
+        context = make_context()
+        from flask import request
+
+        slug = request.path.split('/')[2]
+
+        context['location'] = get_location_by_slug(slug)
+        context['history'] = get_location_history_by_slug(slug)
+
+        return make_response( render_template( 'location.html', **context ) )
+
 
 app.register_blueprint(static.static)
 app.register_blueprint(oauth.oauth)

--- a/app.py
+++ b/app.py
@@ -39,6 +39,14 @@ def index():
 
     return make_response(render_template('index.html', **context))
 
+@app.route('/locations')
+@app.route('/locations/')
+def table_redirect();
+    """
+    redirect people looking for a list of locations to the main page
+    """
+    return redirect( '/', code='303' ) # 303 See Other
+
 @app.route('/table.html')
 def table():
     """
@@ -56,6 +64,29 @@ def embedding():
     context = make_context()
 
     return make_response(render_template('embedding.html', **context))
+
+@app.route('/embedding.html')
+def embedding():
+    """
+    instructions on embedding this item
+    """
+    context = make_context()
+
+    return make_response(render_template('embedding.html', **context))
+
+location_ids = get_location_ids()
+for location in location_ids: # 'id' is a __builtin__
+    @app.route('/location/%s' % location, endpoint=location)
+    def location():
+        context = make_context()
+        from flask import request
+
+        slug = request.path.split('/')[2]
+
+        context['location'] = get_location_by_slug(slug)
+        context['history'] = get_location_history_by_slug(slug)
+        return make_response(render_template('location.html', **context)
+
 
 app.register_blueprint(static.static)
 app.register_blueprint(oauth.oauth)

--- a/app.py
+++ b/app.py
@@ -24,6 +24,8 @@ app.debug = app_config.DEBUG
 app.add_template_filter(smarty_filter, name='smarty')
 app.add_template_filter(urlencode_filter, name='urlencode')
 app.jinja_env.filters['format_zip'] = format_zip
+app.jinja_env.filters['status_color'] = get_location_status_color_by_slug
+app.jinja_env.filters['status_updated'] = get_location_status_updated_by_slug
 
 logging.basicConfig(format=app_config.LOG_FORMAT)
 logger = logging.getLogger(__name__)

--- a/app.py
+++ b/app.py
@@ -85,6 +85,7 @@ for location in location_ids: # 'id' is a __builtin__
 
         context['location'] = get_location_by_slug(slug)
         context['history'] = get_location_history_by_slug(slug)
+        context['status'] = get_location_status_by_slug(slug)
 
         return make_response( render_template( 'location.html', **context ) )
 

--- a/app.py
+++ b/app.py
@@ -13,7 +13,7 @@ import logging
 import oauth
 import static
 
-from flask import Flask, make_response, render_template
+from flask import Flask, make_response, render_template, redirect
 from render_utils import make_context, smarty_filter, urlencode_filter
 from werkzeug.debug import DebuggedApplication
 from helpers import *
@@ -39,6 +39,8 @@ def index():
 
     return make_response(render_template('index.html', **context))
 
+@app.route('/location')
+@app.route('/location/')
 @app.route('/locations')
 @app.route('/locations/')
 def table_redirect():

--- a/helpers.py
+++ b/helpers.py
@@ -6,6 +6,18 @@ import re
 import json
 
 from unicodedata import normalize
+from operator import itemgetter
+
+CACHE = {}
+
+def get_copy():
+    """
+    Thank you Ryan for this neat trick to avoid thrashing the disk
+    https://github.com/INN/maine-legislature/blob/master/helpers.py#L361-L364
+    """
+    if not CACHE.get('copy', None):
+        CACHE['copy'] = copytext.Copy(app_config.COPY_PATH)
+    return CACHE['copy']
 
 # Please test the first two lines against "01234-4567": it should not return "001234-4567"
 # Please test the first two lines against "61234-4567": it should not return "061234-4567"
@@ -19,3 +31,40 @@ def format_zip(zip):
         return zip
     except ValueError:
         return zip
+
+def get_locations():
+    copy = get_copy()
+    return copy['locations']
+
+def get_location_ids():
+    locations = get_locations()
+    ids = []
+    for location in locations:
+        ids.append(location['id'])
+    return ids
+
+def get_location_by_slug(slug):
+    locations = get_locations()
+    place = None
+    for location in locations:
+        if location['id'] == slug:
+            place = location
+            break
+        
+    return place
+
+def get_location_history_by_slug(slug):
+    """
+    return history, sorted by date then time -> dunno how well this will sort, but we shall see
+    """
+    copy = get_copy()
+    history = []
+
+    for row in copy['locations_statuses']:
+        if row['id'] == slug:
+            history.append( row )
+
+        if len( history ) > 1 :
+            history = sorted( history, key=itemgetter( 'date', 'time' ) )
+
+    return history

--- a/helpers.py
+++ b/helpers.py
@@ -76,6 +76,15 @@ def get_location_history_by_slug(slug):
             history.append( row )
 
         if len( history ) > 1 :
-            history = sorted( history, key=itemgetter( 'date', 'time' ) )
+            history = sorted( history, key=itemgetter( 'date', 'time' ), reverse=True )
 
     return history
+
+def get_location_status_by_slug(slug):
+    history = get_location_history_by_slug(slug)
+    print history
+    status = history[0] if history else []
+    if status['color'] not in [u'red', u'yellow', u'green', u'grey']:
+        status['color'] = u'unknown'
+
+    return status

--- a/helpers.py
+++ b/helpers.py
@@ -4,6 +4,7 @@ import collections
 import copytext
 import re
 import json
+import numbers
 
 from unicodedata import normalize
 from operator import itemgetter
@@ -45,7 +46,12 @@ def format_zip(zip):
 
 def get_locations():
     copy = get_copy()
-    return copy['locations']
+    locations = copy['locations']
+    
+    for location in locations:
+        better_id = location['id'].split('.')
+
+    return locations
 
 def get_location_ids():
     locations = get_locations()
@@ -64,14 +70,25 @@ def get_location_by_slug(slug):
         
     return place
 
+def get_locations_statuses():
+    copy = get_copy()
+    statuses = copy['locations_statuses']
+    
+    for status in statuses:
+        if isinstance( status['id'], numbers.Number):
+            status['id'] = int(float( status['id'] ))
+    return statuses
+
 def get_location_history_by_slug(slug):
     """
     return history, sorted by date then time -> dunno how well this will sort, but we shall see
     """
-    copy = get_copy()
+    locations_statuses = get_locations_statuses()
     history = []
 
-    for row in copy['locations_statuses']:
+    for row in locations_statuses:
+        print row['id']
+        print slug
         if row['id'] == slug:
             history.append( row )
 
@@ -82,9 +99,12 @@ def get_location_history_by_slug(slug):
 
 def get_location_status_by_slug(slug):
     history = get_location_history_by_slug(slug)
-    print history
-    status = history[0] if history else []
-    if status['color'] not in [u'red', u'yellow', u'green', u'grey']:
+    try:
+        status = history[0]
+        if status['color'] not in {'red', 'yellow', 'green', 'grey'}:
+            status['color'] = u'unknown'
+    except IndexError:
+        status = {}
         status['color'] = u'unknown'
 
     return status

--- a/helpers.py
+++ b/helpers.py
@@ -7,6 +7,17 @@ import json
 
 from unicodedata import normalize
 
+CACHE = {}
+
+def get_copy():
+    """
+    Thank you Ryan for this neat trick to avoid thrashing the disk
+    https://github.com/INN/maine-legislature/blob/master/helpers.py#L361-L364
+    """
+    if not CACHE.get('copy', None):
+        CACHE['copy'] = copytext.Copy(app_config.COPY_PATH)
+    return CACHE['copy']
+
 # Please test the first two lines against "01234-4567": it should not return "001234-4567"
 # Please test the first two lines against "61234-4567": it should not return "061234-4567"
 def format_zip(zip):
@@ -19,3 +30,36 @@ def format_zip(zip):
         return zip
     except ValueError:
         return zip
+
+def get_locations():
+    copy = get_copy()
+    return copy['locations']
+
+def get_location_ids():
+    locations = get_locations()
+    ids = []
+    for location in locations:
+        ids.append(location['id'])
+    return ids
+
+def get_location_by_slug(slug):
+    locations = get_locations()
+    place = None
+    for location in locations:
+        if location['id'] == slug:
+            place = location
+            break
+        
+    return place
+
+def get_location_history_by_slug(slug):
+    """
+    Executive decision: since we can sort the Google Doc by fields, we can ensure that things are in their correct order
+    And therefore, this can be an Ordered Dict
+    """
+    copy = get_copy()
+    history = []
+
+    for row in copy['locations_statuses']:
+        if row['id'] == slug:
+            try

--- a/helpers.py
+++ b/helpers.py
@@ -87,8 +87,6 @@ def get_location_history_by_slug(slug):
     history = []
 
     for row in locations_statuses:
-        print row['id']
-        print slug
         if row['id'] == slug:
             history.append( row )
 

--- a/helpers.py
+++ b/helpers.py
@@ -100,11 +100,23 @@ def get_location_history_by_slug(slug):
 def get_location_status_by_slug(slug):
     history = get_location_history_by_slug(slug)
     try:
-        status = history[0]
-        if status['color'] not in {'red', 'yellow', 'green', 'grey'}:
-            status['color'] = u'unknown'
+        return history[0]
     except IndexError:
-        status = {}
-        status['color'] = u'unknown'
+        return {}
 
-    return status
+def get_location_status_color_by_slug(slug):
+    status = get_location_status_by_slug(slug)
+    try:
+        if status['color'] not in {'red', 'yellow', 'green', 'grey'}:
+            return u'unknown'
+        else:
+            return status['color']
+    except KeyError:
+        return u'unknown'
+
+def get_location_status_updated_by_slug(slug):
+    status = get_location_status_by_slug(slug)
+    try:
+        return status['date'] + '' +  status['time']
+    except KeyError:
+        return u''

--- a/less/location.less
+++ b/less/location.less
@@ -6,6 +6,38 @@ body {
   padding: 0;
   font-family: @font-family-sans-serif;
 }
+span[class*="status"] {
+  display: inline-block;
+  border: 2px black solid;
+  padding: 3px;
+}
+.status-green {
+  background-color: hsl(120, 100%, 85%);
+}
+.status-yellow {
+  background-color: hsl(60, 100%, 85%);
+}
+.status-red {
+  background-color: hsl( 0, 100%, 85%);
+}
+address {
+  font-style: normal
+}
+article {
+  max-width: 720px;
+  margin: 0 auto;
+}
+header, section {
+  padding: 1em 0.7em;
+}
+header {
+  background-color: #ebebeb;
+}
+
+table .date {
+  min-width: 5.5em;
+}
+
 footer {
   padding: 1em 0.7em;
 

--- a/less/location.less
+++ b/less/location.less
@@ -1,0 +1,20 @@
+@import "less/lib/bootstrap/variables";
+@import "less/variables";
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: @font-family-sans-serif;
+}
+footer {
+  padding: 1em 0.7em;
+
+  color: #444444;
+
+  a {
+    color: #444444;
+    &:hover {
+      color: @primary-control-hover;
+    }
+  }
+}

--- a/templates/_pymchild.html
+++ b/templates/_pymchild.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<script type="text/javascript" src="https://pym.nprapps.org/pym.v1.js"></script>
+		{% block head_stuff %}
+		{% endblock %}
+	</head>
+	<body>
+		
+		{% block body %}
+		{% endblock }
+
+		<script type="text/javascript">
+			var pymChild = new pym.Child({
+				id: 'harvey-table',
+			});
+		</script>
+
+		{% block post_pym %}
+		{% endblock %}
+	</body>
+</html>

--- a/templates/_pymchild.html
+++ b/templates/_pymchild.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<script type="text/javascript" src="https://pym.nprapps.org/pym.v1.js"></script>
+		{% block head_stuff %}
+		{% endblock %}
+	</head>
+	<body>
+		
+		{% block body %}
+		{% endblock %}
+
+		<script type="text/javascript">
+			var pymChild = new pym.Child({
+				id: 'harvey-table',
+			});
+		</script>
+
+		{% block post_pym %}
+		{% endblock %}
+	</body>
+</html>

--- a/templates/_table.html
+++ b/templates/_table.html
@@ -16,7 +16,9 @@
 	<tbody>
 		{% for row in COPY.locations %}
 			<tr>
-				<td>{{ row.location_name }}</td>
+				<td>
+					<a href="{{ S3_BASE_URL }}/location/{{ row.id }}">{{ row.location_name }}</a>
+				</td>
 				<td></td><!-- need a way of getting the actual status, by passing the row ID to a function -->
 				<td></td><!-- same for this, but for the last-updated thing -->
 				<td>{{ row.phone }}</td>

--- a/templates/_table.html
+++ b/templates/_table.html
@@ -1,15 +1,15 @@
-<table class="tablesaw" data-tablesaw-mode="columntoggle">
+<table class="tablesaw" data-tablesaw-mode="columntoggle" data-tablesaw-sortable data-tablesaw-minimap>
 	<thead>
 		<tr>
-			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="persist">Location name</th>
+			<th scope="col" data-tablesaw-sortable-col data-tablesaw-sortable-default-col data-tablesaw-priority="persist">Location name</th>
 			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="persist">Status</th>
 			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="persist">Updated</th>
 			<th scope="col" data-tablesaw-priority="3">Phone</th>
-			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="4">Operator</th>
-			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="4">Address</th>
-			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="1">City</th>
-			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="2">State</th>
-			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="4">ZIP</th>
+			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="5">Operator</th>
+			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="0">Address</th>
+			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="2">City</th>
+			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="4">State</th>
+			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="0">ZIP</th>
 			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="0"><abbr title="Medicare Provider Number">MPN</abbr></th>
 		</tr>
 	</thead>

--- a/templates/_table.html
+++ b/templates/_table.html
@@ -19,12 +19,12 @@
 				<td>
 					<a href="{{ S3_BASE_URL }}/location/{{ row.id }}">{{ row.location_name }}</a>
 				</td>
-				<td></td><!-- need a way of getting the actual status, by passing the row ID to a function -->
-				<td></td><!-- same for this, but for the last-updated thing -->
+				<td>{{ row.id|status_color }}</td><!-- need a way of getting the actual status, by passing the row ID to a function -->
+				<td>{{ row.id|status_updated }}</td><!-- same for this, but for the last-updated thing -->
 				<td>{{ row.phone }}</td>
-				<td>{{ row.location_owner }}</td>
-				<td>{{ row.address }}</td>
-				<td>{{ row.city }}</td>
+				<td>{{ row.location_owner|title }}</td>
+				<td>{{ row.address|title }}</td>
+				<td>{{ row.city|title }}</td>
 				<td>{{ row.state }}</td>
 				<td>{{ row.zip|format_zip }}</td>
 				<td>{{ row.mpn }}</td>

--- a/templates/_table.html
+++ b/templates/_table.html
@@ -7,10 +7,10 @@
 			<th scope="col" data-tablesaw-priority="3">Phone</th>
 			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="4">Operator</th>
 			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="4">Address</th>
-			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="2">City</th>
+			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="1">City</th>
 			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="2">State</th>
-			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="1">ZIP</th>
-			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="6"><abbr title="Medicare Provider Number">MPN</abbr></th>
+			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="4">ZIP</th>
+			<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="0"><abbr title="Medicare Provider Number">MPN</abbr></th>
 		</tr>
 	</thead>
 	<tbody>

--- a/templates/location.html
+++ b/templates/location.html
@@ -7,6 +7,11 @@
 
 {% block body %}
 	<h1>{{ location.location_name }}</h1>
+	{% if status %}
+		<h2>it has a status: {{status.color}}</h2>
+		<p class="status-description">{{ status.status }}</p>
+		<span class="last-updated">Last updated: {{ status.date }} {{ status.time }}
+	{% endif %}
 	<dl>
 		<dt>Owner:</dt>
 			<dd>{{location.location_owner }}</dd>
@@ -22,5 +27,6 @@
 		<dt>Medicare Provider Number</dt>
 			<dd>{{ location.mpn }}</dd>
 		{% endif %}
+
 	</dl>
 {% endblock %}

--- a/templates/location.html
+++ b/templates/location.html
@@ -6,45 +6,67 @@
 {% endblock %}
 
 {% block body %}
-	<a class="back" href="{{ S3_BASE_URL }}/table.html">&larr; back to list</a>
-	<h1>{{ location.location_name }}</h1>
-	{% if status %}
-		<h2>status: {{status.color}}</h2>
-		<p class="status-description">{{ status.status|urlize }}</p>
-		<span class="last-updated">Last updated: {{ status.date }} {{ status.time }}
-	{% endif %}
-	<dl>
-		<dt>Owner:</dt>
-			<dd>{{location.location_owner }}</dd>
-		<dt>Address: </dt>
-			<dd><address>
-				{{ location.address }}<br/>
-				{{ location.city }}, {{ location.state }}, {{ location.zip|format_zip }}
-			</address></dd>
-		<dt>Phone: </dt>
-			<dd>{{ location.phone }}</dd>
-
-		{% if location.mpn %}
-		<dt>Medicare Provider Number</dt>
-			<dd>{{ location.mpn }}</dd>
+<article>
+	<header>
+		<a class="back" href="{{ S3_BASE_URL }}/table.html">&larr; back to list</a>
+		<h1>{{ location.location_name }}</h1>
+		{% if status %}
+			<h2>status: <span class="status-{{status.color}}">{{status.color}}</span></h2>
+			<p class="status-description">
+				{{ status.status|urlize }}
+				<span class="last-updated">Last updated: {{ status.date }} {{ status.time }}
+			</p>
+		{% else %}
+			<h2>status: <span class="status-unknown">unknown</span></h2>
+			<p>This location has no known status. Please contribute status information by following <a href="https://github.com/benlk/harvey-senior-homes/blob/master/contributing.md">the instructions at this link</a>.</p>
 		{% endif %}
-	</dl>
+	</header>
+	<section>
+		<h3>Location information:</h3>
+		<dl>
+			<dt>Owner:</dt>
+				<dd>{{location.location_owner }}</dd>
+			<dt>Address: </dt>
+				<dd><address>
+					{{ location.address }}<br/>
+					{{ location.city }}, {{ location.state }}, {{ location.zip|format_zip }}
+				</address></dd>
+			<dt>Phone: </dt>
+				{% if location.phone %}
+					<dd>{{ location.phone }}</dd>
+				{% else %}
+					<dd>This location has no known phone number. Please contribute one by following the instructions <a href="https://github.com/benlk/harvey-senior-homes/blob/master/contributing.md">at this link</a>.</dd>
+				{% endif %}
 
-	<h3>All previous status updates:</h3>
-	<table>
-		<thead>
-			<tr>
-			</tr>
-		</thead>
-		<tbody>
-			{% for status in history %}
+			{% if location.mpn %}
+			<dt>Medicare Provider Number</dt>
+				<dd>{{ location.mpn }}</dd>
+			{% endif %}
+		</dl>
+	</section>
+	<section>
+		<h3>All status updates:</h3>
+		<table>
+			<thead>
 				<tr>
-					<td>{{ status.date }}</td>
-					<td>{{ status.time }}</td>
-					<td>{{ status.color }}</td>
-					<td>{{ status.status|urlize }}</td>
 				</tr>
-			{% endfor %}
-		</tbody>
-	</table>
+			</thead>
+			<tbody>
+				{% for status in history %}
+					<tr>
+						<td class="date">{{ status.date }}</td>
+						<td class="time">{{ status.time }}</td>
+						<td class="color"><span class="status-{{status.color}}">{{status.color}}</span></td>
+						<td>{{ status.status|urlize }}</td>
+					</tr>
+				{% else %}
+					<p class="status-unknown">This location has no known status. Please contribute status information by following <a href="https://github.com/benlk/harvey-senior-homes/blob/master/contributing.md">the instructions at this link</a>.</p>
+				{% endfor %}
+			</tbody>
+		</table>
+	</section>
+</article>
+<footer>
+	{{ COPY.content.table_footer }}
+</footer>
 {% endblock %}

--- a/templates/location.html
+++ b/templates/location.html
@@ -1,0 +1,26 @@
+{% extends '_pymchild.html' %}
+
+{% block head_stuff %}
+	{{ CSS.push('less/location.less') }}
+	{{ CSS.render('css/rendered/location.min.css') }}
+{% endblock %}
+
+{% block body %}
+	<h1>{{ location.location_name }}</h1>
+	<dl>
+		<dt>Owner:</dt>
+			<dd>{{location.location_owner }}</dd>
+		<dt>Address: </dt>
+			<dd><address>
+				{{ location.address }}<br/>
+				{{ location.city }}, {{ location.state }}, {{ location.zip|format_zip }}
+			</address></dd>
+		<dt>Phone: </dt>
+			<dd>{{ location.phone }}</dd>
+
+		{% if location.mpn %}
+		<dt>Medicare Provider Number</dt>
+			<dd>{{ location.mpn }}</dd>
+		{% endif %}
+	</dl>
+{% endblock %}

--- a/templates/location.html
+++ b/templates/location.html
@@ -6,6 +6,7 @@
 {% endblock %}
 
 {% block body %}
+	<a class="back" href="{{ S3_BASE_URL }}/table.html">&larr; back to list</a>
 	<h1>{{ location.location_name }}</h1>
 	{% if status %}
 		<h2>it has a status: {{status.color}}</h2>

--- a/templates/location.html
+++ b/templates/location.html
@@ -1,0 +1,7 @@
+{% extends '_pymchild.html' %}
+
+{% block head_stuff %}
+{% endblock %}
+
+{% block body %}
+{% endblock %}

--- a/templates/location.html
+++ b/templates/location.html
@@ -10,7 +10,7 @@
 	<h1>{{ location.location_name }}</h1>
 	{% if status %}
 		<h2>status: {{status.color}}</h2>
-		<p class="status-description">{{ status.status }}</p>
+		<p class="status-description">{{ status.status|urlize }}</p>
 		<span class="last-updated">Last updated: {{ status.date }} {{ status.time }}
 	{% endif %}
 	<dl>
@@ -28,6 +28,23 @@
 		<dt>Medicare Provider Number</dt>
 			<dd>{{ location.mpn }}</dd>
 		{% endif %}
-
 	</dl>
+
+	<h3>All previous status updates:</h3>
+	<table>
+		<thead>
+			<tr>
+			</tr>
+		</thead>
+		<tbody>
+			{% for status in history %}
+				<tr>
+					<td>{{ status.date }}</td>
+					<td>{{ status.time }}</td>
+					<td>{{ status.color }}</td>
+					<td>{{ status.status|urlize }}</td>
+				</tr>
+			{% endfor %}
+		</tbody>
+	</table>
 {% endblock %}

--- a/templates/location.html
+++ b/templates/location.html
@@ -9,7 +9,7 @@
 	<a class="back" href="{{ S3_BASE_URL }}/table.html">&larr; back to list</a>
 	<h1>{{ location.location_name }}</h1>
 	{% if status %}
-		<h2>it has a status: {{status.color}}</h2>
+		<h2>status: {{status.color}}</h2>
 		<p class="status-description">{{ status.status }}</p>
 		<span class="last-updated">Last updated: {{ status.date }} {{ status.time }}
 	{% endif %}

--- a/templates/table.html
+++ b/templates/table.html
@@ -1,31 +1,28 @@
-<!DOCTYPE html>
-<html>
-	<head>
-		<script type="text/javascript" src="https://pym.nprapps.org/pym.v1.js"></script>
-		<script>
-		TablesawConfig = {
-			getColumnToggleLabelTemplate: function( text ) {
-				return "<label><input type='checkbox' checked><span>" + text + "</span></label>";
-			}
-		};
-		</script>
+{% extends '_pymchild.html' %}
 
-		{{ CSS.push('less/table.less') }}
-		{{ CSS.push('www/css/tablesaw/tablesaw.css') }}
-		{{ CSS.render('css/rendered/table.min.css') }}
-		{{ JS.push('js/lib/tablesaw.js') }}
-		{{ JS.push('js/lib/tablesaw-init.js') }}
-	</head>
-	<body>
-		{% include '_table.html' %}
-		<footer>
-			{{ COPY.content.table_footer }}
-		</footer>
-		<script type="text/javascript">
-			var pymChild = new pym.Child({
-				id: 'harvey-table',
-			});
-		</script>
-		{{ JS.render('js/table.min.js') }}
-	</body>
-</html>
+{% block head_stuff %}
+	<script>
+	TablesawConfig = {
+		getColumnToggleLabelTemplate: function( text ) {
+			return "<label><input type='checkbox' checked><span>" + text + "</span></label>";
+		}
+	};
+	</script>
+
+	{{ CSS.push('less/table.less') }}
+	{{ CSS.push('www/css/tablesaw/tablesaw.css') }}
+	{{ CSS.render('css/rendered/table.min.css') }}
+	{{ JS.push('js/lib/tablesaw.js') }}
+	{{ JS.push('js/lib/tablesaw-init.js') }}
+{% endblock %}
+
+{% block body %}
+	{% include '_table.html' %}
+	<footer>
+		{{ COPY.content.table_footer }}
+	</footer>
+{% endblock }
+
+{% block post_pym %}
+	{{ JS.render('js/table.min.js') }}
+{% endblock %}

--- a/templates/table.html
+++ b/templates/table.html
@@ -21,7 +21,7 @@
 	<footer>
 		{{ COPY.content.table_footer }}
 	</footer>
-{% endblock }
+{% endblock %}
 
 {% block post_pym %}
 	{{ JS.render('js/table.min.js') }}

--- a/www/css/tablesaw/tablesaw.css
+++ b/www/css/tablesaw/tablesaw.css
@@ -615,9 +615,6 @@ a.tablesaw-btn {
     display: table-cell;
   }
 
-  .tablesaw-columntoggle tbody td {
-    line-height: 2;
-  }
 }
 
 /* Show priority 4 at 800px (50em x 16px) */


### PR DESCRIPTION
# Changes

- adds embedding instructions at `/embedding.html`
- adds locations to `/location/id` where `id` is in the `id` column:
    - top-of-view status, location information
    - full location history ~~(looks kinda ugly)~~
- adds a redirect so that people who URL-hack to `/location/` or its ilk go back to the main page
- adds a whole bunch of helpers
- creates `templates/_pymchild.html`, an abstraction used now by `table.html` and the per-location views.
- titlecases a bunch of stuff in the table
- messes with priority of visibility of things in the table

For #10 